### PR TITLE
Update URL for select child layers plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A list of Sketch plugins hosted at GitHub, in no particular order.
 - [jimrutherford/Random-User](https://github.com/jimrutherford/random-user) A SketchApp plugin that inserts random user data into your Sketch documents
 - [timuric/Content-generator-sketch-plugin](https://github.com/timuric/content-generator-sketch-plugin) Sketch app plugin for generating dummy data such as avatars, names, photos, geo data etc
 - [alessndro/sketch-plugins](https://github.com/alessndro/sketch-plugins) An incredible collection of plugins, including some great ones for working with baselines.
-- [mattmcmanus/select-child-layers.sketchplugin](https://github.com/mattmcmanus/select-child-layers.sketchplugin) Select all child layers of a group with a key command
+- [mattmcmanus/select-child-layers-sketch-plugin](https://github.com/mattmcmanus/select-child-layers-sketch-plugin) Select all child layers of a group with a key command
 - [bomberstudios/sketch-duplicate-and-nudge](https://github.com/bomberstudios/sketch-duplicate-and-nudge) A port to Sketch.app of Photoshop's Duplicate and Nudge feature
 - [jelias/sketch-upload](https://github.com/jelias/sketch-upload) This Sketch plugin allows designers to upload the selected artboard or slice to Cloud App with a simple shortcut ⇧⌘U
 - [joshpuckett/SketchPlugins](https://github.com/joshpuckett/sketchplugins) A git repo containing various plugins for Sketch (including 'Handy', a plugin that makes working with guides easier)

--- a/plugins.json
+++ b/plugins.json
@@ -186,7 +186,7 @@
     },
     {
         "description": "Select all child layers of a group with a key command",
-        "name": "select-child-layers.sketchplugin",
+        "name": "select-child-layers-sketch-plugin",
         "owner": "mattmcmanus"
     },
     {


### PR DESCRIPTION
The original name for this repo ended with .sketchplugin which I believe is causing problems with how Sketch Toolbox was checking out the repo in the plugin's directory. I think Sketch was thinking the folder, named `Select Child Layers.sketchplugin` was actually the plugin and nothing was working. 
