### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+To add a new plugin to the directory:
+
+1. Fork the repo (create a new branch as well if you want)
+2. Modify `plugins.json` by adding your plugin
+3. Run `rake` to update the `README.md` file
+4. Push your changes to your fork and [submit a pull request](https://github.com/sketchplugins/plugin-directory/compare/)
+
+Thanks in advance!


### PR DESCRIPTION
I noticed @bomberstudios often have to write something along these lines when there is a new issue created.

By creating this file it should show up when people create new issues or open up pull requests:

See blog post about [Contributing Guidelines](https://github.com/blog/1184-contributing-guidelines).

----
![](https://camo.githubusercontent.com/71995d6b0e620a9ef1ded00a04498241c69dd1bf/68747470733a2f2f6769746875622d696d616765732e73332e616d617a6f6e6177732e636f6d2f736b697463682f6973737565732d32303132303931332d3136323533392e6a7067)