### PR TITLE
Added text-align plugin, fix issue on osx with default US-ASCII encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [AntonStrand/Sketch-Resize](https://github.com/antonstrand/sketch-resize) Use one layer or the artboard as a template to resize other layers.
 - [Arkkimaagi/ArtboardZoom](https://github.com/arkkimaagi/artboardzoom) "Zoom" to currently selected Artboard.
 - [automat/sketch-plugin-typographic-scale](https://github.com/automat/sketch-plugin-typographic-scale) Generates a typographic scale from selected text layers.
+- [bitinn/sketch-text-align](https://github.com/bitinn/sketch-text-align) Properly align text layers regardless of their rectangle box in Sketch.
 - [bomberstudios/sketch-commands](https://github.com/bomberstudios/sketch-commands) A collection of script commands for Bohemian Coding's Sketch.app
 - [bomberstudios/sketch-duplicate-and-nudge](https://github.com/bomberstudios/sketch-duplicate-and-nudge) A port to Sketch.app of Photoshop's Duplicate and Nudge feature.
 - [bomberstudios/sketch-framer](https://github.com/bomberstudios/sketch-framer) A plugin to export Sketch.app documents into FramerJS to make interactive prototypes.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'json'
 
-plugins = JSON.parse(IO.read('plugins.json'))
+data = IO.read('plugins.json')
+data.force_encoding('utf-8')
+plugins = JSON.parse(data)
 
 desc "Clones all repositories to the 'clones' folder"
 task :clone do

--- a/plugins.json
+++ b/plugins.json
@@ -743,5 +743,10 @@
         "description": "Official export plugin for Facebook's Origami for Quartz Composer.",
         "name": "sketch-origami-export",
         "owner": "tarngerine"
+    },
+    {
+        "description": "Properly align text layers regardless of their rectangle box in Sketch.",
+        "name": "sketch-text-align",
+        "owner": "bitinn"
     }
 ]


### PR DESCRIPTION
Added my text-align plugin.

A small change to rakefile to make sure `plugins.json` are decoded as UTF-8, otherwise I got this error.

```
$ rake        
rake aborted!
"\xC3" on US-ASCII
/Users/df/git/code/plugin-directory/Rakefile:3:in `<top (required)>'
```