### PR TITLE
Fix the britesnow/sketch-storyboard name in the plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -766,7 +766,7 @@
     },
     {
         "description": "Turn your artboards into storyboards.",
-        "name": "Storyboard",
+        "name": "sketch-storyboard",
         "owner": "BriteSnow"
     }
 


### PR DESCRIPTION
Sorry, put the wrong .name value in the plugins.json which brake the install (Thought it was the "display name")

This should fix it. 

Thanks