### PR TITLE
Sketch-iOS-Bar-Color-Calculator plugin name and link fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [design4use/gb-sketch-nudge](https://github.com/design4use/gb-sketch-nudge) Nudge ↓ ← ↑ → by a customizable number of pixels
 - [dunckr/sketch-colorfulgradients](https://github.com/dunckr/sketch-colorfulgradients) Import gradients as shape fills using Will Burn's colorfulgradients and colorincolor.
 - [dunckr/sketch-subtlepatterns](https://github.com/dunckr/sketch-subtlepatterns) Import subtle patterns as shape fills in Sketch.
-- [einancunlu/Sketch-iOS-Bar-Color-Calculator](https://github.com/einancunlu/Sketch-iOS-Bar-Color-Calculator) A Sketch plugin that calculates and applies the correct color for you to get actual design color after applying it to a translucent UIToolbar or UINavigationBar.
+- [einancunlu/Sketch-iOS-Bar-Color-Calculator](https://github.com/einancunlu/sketch-ios-bar-color-calculator) A Sketch plugin that calculates and applies the correct color for you to get actual design color after applying it to a translucent UIToolbar or UINavigationBar.
 - [eivindbohler/Sketch-Unlinker](https://github.com/eivindbohler/sketch-unlinker) Sketch plugin that lets you unlink selected layers and groups from either shared symbols, styles or text styles, en masse.
 - [elihorne/smartboards](https://github.com/elihorne/smartboards) Smartboards is a collection of plugins that make my life easier in Sketch.
 - [eric-adstage/Sketch_RotateLine](https://github.com/eric-adstage/sketch_rotateline) More precise rotation for line objects in Sketch compared to the native Rotate tool, which only offers arbitrary rotation. Includes a 'Rotate a Copy' feature and Relative and Absolute rotation as well.

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 [
     {
         "description": "A Sketch plugin that calculates and applies the correct color for you to get actual design color after applying it to a translucent UIToolbar or UINavigationBar.",
-        "name": "iOS-Bar-Color-Calculator",
+        "name": "Sketch-iOS-Bar-Color-Calculator",
         "owner": "einancunlu"
     },
     {


### PR DESCRIPTION
Hello, 

Sorry, yesterday it was my first pull request / contribution, and I made some mistakes as I see. When I checked my plugin from Sketch Toolbox app, the link wasn't working. So I fixed the plugins.json file and run rake comment to update README.md file this time. 

Thanks for understanding and sorry again. : )