### PR TITLE
Renamed plugin & install issue fix?

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1291,7 +1291,7 @@
     },
     {
         "description": "Sketch-flavored Auto Layout-like Constraints",
-        "name": "Sketch-Constraints",
+        "name": "fluid-for-sketch",
         "owner": "matt-curtis"
     }
 ]


### PR DESCRIPTION
Plugin named changed from "Sketch Constraints" to "Fluid". Also, for some reason, we've been getting reports that installs via Sketch Toolbox have been failing. Hopefully this fixes that?