### PR TITLE
Update plugins.json with disclaimer for Fluid

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1290,7 +1290,7 @@
         "owner": "swiadek"
     },
     {
-        "description": "Sketch-flavored Auto Layout-like Constraints",
+        "description": "Sketch-flavored Auto Layout-like Constraints [MUST BE INSTALLED MANUALLY - SEE README.]",
         "name": "fluid-for-sketch",
         "owner": "matt-curtis"
     },


### PR DESCRIPTION
Added disclaimer as installs of Fluid via Sketch Toolbox are not working atm.

See this issue: https://github.com/buzzfeed/Sketch-Toolbox/issues/61 and this issue: https://github.com/matt-curtis/Fluid-for-Sketch/issues/15

I'm adding a disclaimer rather than removing it entirely to deter others adding it.