### PR TITLE
Removing Marvel from this list, since Sketch Toolbox breaks our plugin.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1099,14 +1099,6 @@
     "owner": "BriteSnow"
   },
   {
-    "description": "Export your artboards to your Marvel prototypes.",
-    "name": "marvel-sketch",
-    "title": "Marvel",
-    "author": "Marvel Prototyping",
-    "owner": "marvelapp",
-    "homepage": "https://marvelapp.com/prototype-with-sketch/"
-  },
-  {
     "description": "Nudge ↓ ← ↑ → by a customizable number of pixels",
     "name": "gb-sketch-nudge",
     "title": "Sketch Nudge",


### PR DESCRIPTION
When a user installs our plugin using the Sketch Toolbox the executables stop working due to the unzipping. So for now we are removing Marvel from this list.