### PR TITLE
Remove sketch-create-nested-symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [Copy Swift Code](https://github.com/ngs/sketchplugin-swift-color), by Atsushi NAGASE: A Sketch Plugin for generating UIColor and NSColor initializer Swift code from fill color of selected layers.
 - [Corner Radius Shortcuts Plugin for Sketch](https://github.com/arjenvr/sketch-radius), by Arjen van Reeven: Sketch plugin to increase or decrease the corner radius on rectangle shapes using keyboard shortcuts.
 - [Cover Artboard](https://github.com/sebj/cover-artboard), by Seb Jachec: Resizes the selected layer to cover its containing artboard in Sketch.
-- [Create Nested Symbol](https://github.com/mludowise/sketch-create-nested-symbol), by mludowise: Sketch plugin to create nested symbols.
 - [CSS Buddy](https://github.com/jodyheavener/css-buddy), by Jody Heavener: A Sketch 3 plugin that allows you to use CSS on layers.
 - [CSS Sprite Mixin](https://github.com/littlebusters/sketch-css-sprite-mixin), by littlebusters: Copy mixin code for SCSS, Less and Stylus to clipboard in Sketch 3.
 - [CSSketch](https://github.com/johncoates/cssketch), by John Coates: CSS Stylesheet integration to improve your workflow, with Less support. Attach once, updates your design automatically on stylesheet changes.

--- a/plugins.json
+++ b/plugins.json
@@ -1731,12 +1731,6 @@
     "owner": "kang-chen"
   },
   {
-    "description": "Sketch plugin to create nested symbols.",
-    "name": "sketch-create-nested-symbol",
-    "title": "Create Nested Symbol",
-    "owner": "mludowise"
-  },
-  {
     "description": "A plugin to save and use the average color of an image.",
     "name": "sketch-ImageAverageColor",
     "title": "Sketch Image Average Color",


### PR DESCRIPTION
The sketch-create-nested-symbol plugin is no longer needed since Sketch
now supports nested symbols and this plugin works less reliably than
the built-in Sketch functionality.