### PR TITLE
Rakefile to prompt user for values to add to plugins.json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -192,7 +192,7 @@ task :authors do
   puts "\n" + authors.size.to_s + " unique authors."
 end
 
-desc "Interactive JSON"
+desc "Interactive JSON: prompt user for information about their plugin and generate plugins.json and README.md"
 task :interactive_update_json_readme do
     begin
         plugin = prompt_for_plugin()
@@ -508,5 +508,5 @@ def check_for_duplicates(plugin, plugins)
     return -1
 end
 
-desc "Default: prompt user for information about their plugin and generate plugins.json and README.md"
-task :default => :interactive_update_json_readme
+desc "Default: generate README.md from plugin"
+task :default => :readme

--- a/Rakefile
+++ b/Rakefile
@@ -496,10 +496,10 @@ end
 
 def check_for_duplicates(plugin, plugins)
     plugins.each_with_index do |saved_plugin, index|
-        if (plugin["name"] == nil || saved_plugin["name"] == nil) && plugin["owner"] == saved_plugin["owner"] && plugin["title"] == saved_plugin["title"]
+        if (plugin["name"] == nil || saved_plugin["name"] == nil) && plugin["owner"].downcase == saved_plugin["owner"].downcase && plugin["title"].downcase == saved_plugin["title"].downcase
             STDOUT.puts "ERROR: Found another plugin with the same owner & title."
             return index
-        elsif plugin["name"] == saved_plugin["name"] && plugin["owner"] == saved_plugin["owner"]
+        elsif plugin["name"] != nil && saved_plugin["name"] != nil && plugin["name"].downcase == saved_plugin["name"].downcase && plugin["owner"].downcase == saved_plugin["owner"].downcase
             STDOUT.puts "ERROR: Found another plugin with the same name & owner."
             return index
         end

--- a/Rakefile
+++ b/Rakefile
@@ -192,5 +192,321 @@ task :authors do
   puts "\n" + authors.size.to_s + " unique authors."
 end
 
-desc "Default: generate README.md from plugin"
-task :default => :readme
+desc "Interactive JSON"
+task :interactive_update_json_readme do
+    begin
+        plugin = prompt_for_plugin()
+
+        # Save JSON
+        save_json(plugin)
+        STDOUT.puts "plugins.json saved."
+
+        # Create readme
+        Rake::Task["readme"].invoke
+        STDOUT.puts "README.md updated."
+
+        STDOUT.puts "To commit your plugin to the plugin directory, open a pull request for https://github.com/sketchplugins/plugin-directory/."
+    rescue SystemExit, Interrupt # Allow for interupt to leave script
+        exit
+    end
+end
+
+def prompt_for_plugin()
+    if prompt_yes_no("Is your plugin hosted on GitHub?")
+        return prompt_gh_plugin()
+    else
+        return prompt_inputs({}, false)
+    end
+end
+
+def prompt_gh_plugin()
+    STDOUT.puts "What is the URL of your GitHub project?"
+    input = STDIN.gets.strip
+    matches = input.match('(https?://)?github.com/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/?')
+    owner = matches[2]
+    name = matches[3]
+
+    if owner && name
+        STDOUT.puts "Repository owner: '#{owner}', name: '#{name}'"
+
+        # Get info from GitHub
+        gh_defaults = get_gh_defaults(owner, name)
+
+        # Use branch to get manifest.json, but don't include in final saved JSON
+        branch = gh_defaults.delete("branch")
+
+        # Get info from manifest.json file hosted on Git?Hub
+        manifest_defaults = get_manifest_defaults(owner, name, branch)
+
+        # Combine info into default values
+        defaults = gh_defaults.merge(manifest_defaults)
+
+        # Prompt for plugin
+        return prompt_inputs(defaults, true)
+    else
+        STDOUT.puts "ERROR: '#{input}' is not a valid GitHub repoistory."
+        prompt_gh_url()
+    end
+end
+
+def prompt_inputs(defaults, has_github)
+    plugin = defaults
+    if !has_github
+        plugin['owner'] = prompt_owner()
+    end
+
+    plugin['title'] = prompt_item("Enter a title for your plugin", defaults["title"], !has_github)
+    plugin['description'] = prompt_item("Describe your plugin in 1-2 sentences", defaults["description"], true)
+    plugin['homepage'] = prompt_item("Enter a the homepage for your plugin", defaults["homepage"], !has_github)
+    plugin['author'] = prompt_item("Enter your name", defaults["author"], false)
+
+    # Filter out nil values
+    plugin = plugin.select{|k,v| v != nil}
+
+    # Get string representation of plugin options
+    str = plugin.map{|k,v| "\t#{k}: #{v}"}.join("\n")
+
+    STDOUT.puts "Your plugin:\n" + str
+
+    if !prompt_yes_no("Is the above information correct?")
+        return prompt_inputs(defaults, has_github)
+    end
+
+    return plugin
+end
+
+def prompt_owner()
+    owner = prompt_item("Enter the person or organization who owns this plugin (no spaces or special characters)", nil, true)
+
+    if !(owner =~ /^[a-zA-Z0-9_\-]+$/)
+        STDOUT.puts "ERROR: Owner can only contain letters, numbers, hyphen, or underscores."
+        return prompt_owner()
+    end
+
+    return owner
+end
+
+def prompt_item(prompt, default, required)
+    if required
+        prompt = prompt + " (required)"
+    else
+        prompt = prompt + " (optional)"
+    end
+
+    prompt = prompt + ": "
+
+    if default
+        prompt = prompt + "#{default}"
+    end
+
+    STDOUT.puts prompt
+    input = STDIN.gets.strip
+
+    if input.to_s.empty? && default
+        return default
+    elsif input.to_s.empty? && !required
+        return nil
+    elsif !(input.to_s.empty?)
+        return input
+    end
+
+    STDOUT.puts "ERROR: Required field"
+    return prompt_item(prompt, default, required)
+end
+
+def get_gh_defaults(owner, name)
+    require 'octokit'
+    client = Octokit::Client.new()
+    repo_name = "#{owner}/#{name}"
+    defaults = {}
+
+    STDOUT.puts "Checking for '#{repo_name}' on GitHub..."
+    begin
+        repo = client.repo(repo_name)
+
+        defaults["owner"] = owner
+        defaults["name"] = name
+
+        if !(repo.homepage.to_s.empty?)
+            defaults["homepage"] = repo.homepage
+        else
+            defaults["homepage"] = repo.html_url
+        end
+
+        if !(repo.description.to_s.empty?)
+            defaults["description"] = repo.description
+        end
+
+        defaults["lastUpdated"] = repo.updated_at
+        defaults["branch"] = repo.default_branch
+
+        return defaults
+    rescue SystemExit, Interrupt # Allow for interupt to leave script
+        exit
+    rescue # Error contacting GitHub API
+        STDOUT.puts "ERROR: The repository '#{repo_name}' does not exist or is not publically accessible on GitHub."
+        exit
+    end
+end
+
+def get_manifest_defaults(owner, name, branch)
+    content = get_manifest_content(owner, name, branch)
+    if !content
+        return {}
+    end
+
+    defaults = {}
+    begin
+        manifest = JSON.parse(content)
+
+        name = manifest['name']
+        description = manifest['description']
+        author = manifest['author']
+        homepage = manifest['homepage']
+        identifier = manifest['identifier']
+        version = manifest['version']
+
+        error = false
+        if identifier.to_s.empty?
+            error = true
+            STDOUT.puts "ERROR: The manifest.json file does not contain an identifier."
+        end
+        if version.to_s.empty?
+            error = true
+            STDOUT.puts "ERROR: The manifest.json file does not contain a version."
+        end
+
+        if error
+            STDOUT.puts "\tWe suggest that you update your plugin's manifest.json file to contain these values before adding it to the plugin-directory."
+            STDOUT.puts "\tSee Sketch's requirements for plugin bundles: http://developer.sketchapp.com/introduction/plugin-bundles/"
+
+            prompt_continue()
+        end
+
+        if !(name.to_s.empty?)
+            defaults['title'] = name
+        end
+        if !(author.to_s.empty?)
+            defaults['author'] = author
+        end
+        if !(homepage.to_s.empty?)
+            defaults['homepage'] = homepage
+        end
+        if !(description.to_s.empty?)
+            defaults['description'] = description
+        end
+
+        return defaults
+
+    rescue JSON::ParserError
+        STDOUT.puts "ERROR: The manifest.json file for this plugin is not valid JSON."
+        STDOUT.puts "\tWe suggest that you update your plugin to contain a valid manifest.json file before adding it to the plugin-directory."
+        STDOUT.puts "\tTry using a JSON validator to check its contents: https://jsonformatter.curiousconcept.com/"
+
+        prompt_continue()
+
+        return {}
+    end
+end
+
+def get_manifest_content(owner, name, branch)
+    require 'octokit'
+    client = Octokit::Client.new()
+    repo_name = "#{owner}/#{name}"
+
+    STDOUT.puts "Checking for manifest.json file in '#{repo_name}' on GitHub..."
+    begin
+        tree = client.tree(repo_name, branch, :recursive => true)
+
+        tree.tree.each do |item|
+            path = item.path
+            if !(path.downcase.end_with? "manifest.json")
+                next
+            end
+
+            sha = item.sha
+
+            blob = client.blob(repo_name, sha)
+            encoding = blob.encoding
+            content = blob.content
+            if encoding == "base64"
+                content = Base64.decode64(content)
+            end
+
+            return content
+        end
+
+        STDOUT.puts "ERROR: The plugin in the repository '#{repo_name}' does not have a manifest.json file."
+        STDOUT.puts "\tWe suggest that you update your plugin to contain a valid manifest.json file before adding it to the plugin-directory."
+        STDOUT.puts "\tSee Sketch's requirements for plugin bundles: http://developer.sketchapp.com/introduction/plugin-bundles/"
+
+        prompt_continue()
+
+        return nil
+
+    rescue SystemExit, Interrupt # Allow for interupt to leave script
+        exit
+    rescue # Error contacting GitHub API
+        puts e
+        STDOUT.puts "ERROR: The repository '#{repo_name}' does not exist or is not publically accessible on GitHub."
+        exit
+    end
+end
+
+def prompt_continue()
+    if !prompt_yes_no("Are you sure you want to continue?")
+        exit
+    end
+end
+
+def prompt_yes_no(prompt)
+    STDOUT.puts prompt + " (y/n)"
+    input = STDIN.gets.strip
+    if input.downcase.start_with?('y')
+        return true
+    elsif input.downcase.start_with?('n')
+        return false
+    else
+        STDOUT.puts "ERROR: Respond with 'y' or 'n'."
+        return prompt_yes_no(prompt)
+    end
+end
+
+def save_json(plugin)
+    # Get current plugins
+    plugins = get_plugins_from_json
+
+    # Check for duplicates
+    existing_plugin_index = check_for_duplicates(plugin, plugins)
+
+    if existing_plugin_index >= 0
+        if prompt_yes_no("Would you like to update the existing plugin instead?")
+            plugins[existing_plugin_index] = plugin
+        else
+            exit
+        end
+    else
+        plugins << plugin
+    end
+
+    File.open("plugins.json","w") do |f|
+      f.write(JSON.pretty_generate(plugins, :indent => "  "))
+    end
+end
+
+def check_for_duplicates(plugin, plugins)
+    plugins.each_with_index do |saved_plugin, index|
+        if (plugin["name"] == nil || saved_plugin["name"] == nil) && plugin["owner"] == saved_plugin["owner"] && plugin["title"] == saved_plugin["title"]
+            STDOUT.puts "ERROR: Found another plugin with the same owner & title."
+            return index
+        elsif plugin["name"] == saved_plugin["name"] && plugin["owner"] == saved_plugin["owner"]
+            STDOUT.puts "ERROR: Found another plugin with the same name & owner."
+            return index
+        end
+    end
+
+    return -1
+end
+
+desc "Default: prompt user for information about their plugin and generate plugins.json and README.md"
+task :default => :interactive_update_json_readme

--- a/Rakefile
+++ b/Rakefile
@@ -420,7 +420,7 @@ def get_manifest_content(owner, name, branch)
 
         tree.tree.each do |item|
             path = item.path
-            if !(path.downcase.end_with? "manifest.json")
+            if !(path.downcase.end_with? ".sketchplugin/contents/sketch/manifest.json")
                 next
             end
 


### PR DESCRIPTION
This is a proposal to update the Rakefile to run an interactive command line interface to update the plugins.json file and generate the README.

The rake task enforces:
  - Github hosted projects have the correct corresponding name & owner.
  - Non Github hosted projects do not have a name (so as not to break Sketch Toolbox) and contain a homepage.
  - The name/owner or title/owner combination is unique to the plugins.json file (no duplicates).

It also warns if the manifest.json file
  - Isn't present in the GitHub repo
  - Is invalid JSON
  - Is missing an identifier or version

And defaults the JSON values based on values from the manifest.json file.

Here is an example of what the typical interaction looks like for my own plugin:
```
$ rake
Is your plugin hosted on GitHub? (y/n)
y
What is the URL of your GitHub project?
https://github.com/mludowise/Sketch-HTML-Export
Repository owner: 'mludowise', name: 'Sketch-HTML-Export'
Checking for 'mludowise/Sketch-HTML-Export' on GitHub...
Checking for manifest.json file in 'mludowise/Sketch-HTML-Export' on GitHub...
Enter a title for your plugin (optional): HTML Export

Describe your plugin in 1-2 sentences (required): Export HTML from a Sketch file.

Enter a the homepage for your plugin (optional): https://github.com/mludowise/Sketch-HTML-Export

Enter your name (optional): Mel Ludowise

Your plugin:
	owner: mludowise
	name: Sketch-HTML-Export
	homepage: https://github.com/mludowise/Sketch-HTML-Export
	description: Export HTML from a Sketch file.
	lastUpdated: 2017-04-16 16:34:41 UTC
	title: HTML Export
	author: Mel Ludowise
Is the above information correct? (y/n)
y
plugins.json saved.
README.md updated.
To commit your plugin to the plugin directory, open a pull request for https://github.com/sketchplugins/plugin-directory/.
```

For plugins that don't have  GitHub repo, the interaction looks like:
```
$ rake
Is your plugin hosted on GitHub? (y/n)
n
Enter the person or organization who owns this plugin (no spaces or special characters) (required): 
some-organization
Enter a title for your plugin (required): 
Example Plugin
Describe your plugin in 1-2 sentences (required): 
This is an amazing plugin that does awesome stuff.
Enter a the homepage for your plugin (required): 
http://somesite.com
Enter your name (optional): 
Jane Doe
Your plugin:
	owner: some-organization
	title: Example Plugin
	description: This is an amazing plugin that does awesome stuff.
	homepage: http://somesite.com
	author: Jane Doe
Is the above information correct? (y/n)
y
plugins.json saved.
README.md updated.
To commit your plugin to the plugin directory, open a pull request for https://github.com/sketchplugins/plugin-directory/.
```