### PR TITLE
CanvasFlip Sketch Plugin add request

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [Bootstrap Guides](https://github.com/tomoyukikashiro/sketch-bootstrap-guides), by Tomoyuki Kashiro: Generate guides along with twitter bootstrap grid system.
 - [Bound with Box](https://github.com/lewishowles/sketch-bound-with-box), by Lewis Howles: Draws a rectangle of the same size, shape and position as the selected layer, with possible padding.
 - [Butter](https://github.com/pberrecloth/butter-sketch-plugin), by Peter Berrecloth: Butter will butt your layers together.
+- [CanvasFlip](https://canvasflip.com/), by CanvasFlip: CanvasFlip Sketch Plugin.
 - [Changelog](https://github.com/jacopocolo/changelog.sketchplugin), by Jacopo Colò: A simple Sketch plugin to generate artboard-based changelogs
 - [Character Count](https://github.com/andrewfiorillo/sketch-character-count), by Andrew Fiorillo: Sketch plugin to count number of characters in a text layer
 - [Charts](https://github.com/nolastan/charts.sketchplugin), by Stanford Rosenthal: Quickly insert charts into Sketch.
@@ -355,6 +356,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 
 ## Sorted by last update (newest on top)
 
+- [CanvasFlip](https://canvasflip.com/), by CanvasFlip: CanvasFlip Sketch Plugin.
 - [Sketch Show Layer Info](https://github.com/mrpeak/sketch-show-layer-info), by 捻捻转儿: Show selected layer's ObjectID, Class and ID. It is of great use for plugin development or file parsing.
 - [Palette Stripes](https://github.com/sureskumar/palette-stripes), by Sures Kumar: Generate palette stripes in sketch from shape fills.
 - [Sketch Search Everywhere](https://github.com/mrpeak/sketch-search-everywhere), by 捻捻转儿: Search layer and select it, by matching textValue, name or ObjectID.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [Bootstrap Guides](https://github.com/tomoyukikashiro/sketch-bootstrap-guides), by Tomoyuki Kashiro: Generate guides along with twitter bootstrap grid system.
 - [Bound with Box](https://github.com/lewishowles/sketch-bound-with-box), by Lewis Howles: Draws a rectangle of the same size, shape and position as the selected layer, with possible padding.
 - [Butter](https://github.com/pberrecloth/butter-sketch-plugin), by Peter Berrecloth: Butter will butt your layers together.
-- [CanvasFlip](https://canvasflip.com/), by CanvasFlip: CanvasFlip Sketch Plugin.
+- [CanvasFlip](https://canvasflip.com/), by CanvasFlip: Sync and generate specs from sketch artboards to CanvasFlip.
 - [Changelog](https://github.com/jacopocolo/changelog.sketchplugin), by Jacopo Colò: A simple Sketch plugin to generate artboard-based changelogs
 - [Character Count](https://github.com/andrewfiorillo/sketch-character-count), by Andrew Fiorillo: Sketch plugin to count number of characters in a text layer
 - [Charts](https://github.com/nolastan/charts.sketchplugin), by Stanford Rosenthal: Quickly insert charts into Sketch.
@@ -356,7 +356,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 
 ## Sorted by last update (newest on top)
 
-- [CanvasFlip](https://canvasflip.com/), by CanvasFlip: CanvasFlip Sketch Plugin.
+- [CanvasFlip](https://canvasflip.com/), by CanvasFlip: Sync and generate specs from sketch artboards to CanvasFlip.
 - [Sketch Show Layer Info](https://github.com/mrpeak/sketch-show-layer-info), by 捻捻转儿: Show selected layer's ObjectID, Class and ID. It is of great use for plugin development or file parsing.
 - [Palette Stripes](https://github.com/sureskumar/palette-stripes), by Sures Kumar: Generate palette stripes in sketch from shape fills.
 - [Sketch Search Everywhere](https://github.com/mrpeak/sketch-search-everywhere), by 捻捻转儿: Search layer and select it, by matching textValue, name or ObjectID.

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "CanvasFlip Sketch Plugin.",
+    "description": "Sync and generate specs from sketch artboards to CanvasFlip.",
     "name": "canvasflip_sketch_sync",
     "title": "CanvasFlip",
     "owner": "canvasflip",

--- a/plugins.json
+++ b/plugins.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "CanvasFlip Sketch Plugin.",
+    "name": "canvasflip_sketch_sync",
+    "title": "CanvasFlip",
+    "owner": "canvasflip",
+    "author": "CanvasFlip",
+    "homepage": "https://canvasflip.com/",
+    "lastUpdated": "2017-06-28 10:30:30 UTC"
+  },
+  {
     "description": "Generate palette stripes in sketch from shape fills.",
     "name": "palette-stripes",
     "title": "Palette Stripes",


### PR DESCRIPTION
Please add CanvasFlip Sketch plugin. The plugin is designed to sync and generate specs from sketch artboards to CanvasFlip.