### PR TITLE
Add the kd-co/charapara-sketch-extension plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3974,5 +3974,13 @@
     "owner": "andex",
     "name": "ColorBrightness",
     "lastUpdated": "2018-05-16 17:53:42 UTC"
+  },
+  {
+    "title": "charapara",
+    "description": "Charapara, an initiative by Kerala Designers Collaborative (KDCo), is a dummy text generator for Malayalam",
+    "name": "charapara-sketch-extension",
+    "owner": "kd-co",
+    "appcast": "https://raw.githubusercontent.com/kd-co/charapara-sketch-extension/master/.appcast.xml",
+    "homepage": "https://github.com/kd-co/charapara-sketch-extension"
   }
 ]


### PR DESCRIPTION
Charapara, an initiative by Kerala Designers Collaborative (KDCo), is a dummy text generator for Malayalam, the regional language used in Kerala, India. 