### PR TITLE
add AutoFixiOSTextLineHeight 

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,3 +907,4 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [Get Margins](https://github.com/peterwooley/get-margins), by Peter Wooley: Gets the margins between an inner and outer layer and then copies the results to the clipboard as CSS.
 - [Select Child Layers](https://github.com/jshuaf/select-children), by Joshua Fang: A sketch plugin to select all the child layers of a group.
 - [PaintCode Code Generator](https://www.paintcodeapp.com/sketch), by PixelCut: Convert your Sketch drawings into Swift or Objective-C
+- [AutoFixiOSTextLineHeight](https://github.com/youngxkk/AutoFixiOSTextLineHeight), by youngxkk: Auto Fix iOS Text Line Height, so that the font restoration degree of iOS design draft reaches 100%.

--- a/plugins.json
+++ b/plugins.json
@@ -4060,5 +4060,14 @@
     "owner": "Frontify",
     "appcast": "https://raw.githubusercontent.com/Frontify/sketch/master/.appcast.xml",
     "homepage": "https://github.com/Frontify/sketch"
+  },
+  {
+    "title": "AutoFixiOSTextLineHeight",
+    "description": "Auto Fix iOS Text Line Height, so that the font restoration degree of iOS design draft reaches 100%.",
+    "name": "AutoFixiOSTextLineHeight-Sketch-Plugin",
+    "owner": "youngxkk",
+    "homepage": "https://github.com/youngxkk/AutoFixiOSTextLineHeight",
+    "author": "youngxkk",
+    "lastUpdated": "2018-06-19 17:45:55 UTC"
   }
 ]


### PR DESCRIPTION
Auto Fix iOS Text Line Height, so that the font restoration degree of iOS design draft reaches 100%.
Accurate to different font sizes