### PR TITLE
Drafta plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [Design Systems](https://github.com/ashung/design-systems), by Ashung Hung: Help you find out popular design systems and download official Sketch UI kit.
 - [Diverse UI Sketch Plugin](https://github.com/reneepadgham/diverseui-sketch-plugin), by Renée Padgham: The official Sketch plugin for Diverse UI.
 - [Dockpreview](https://github.com/fnky/sketch-dockpreview), by Christian Petersen: A Sketch plugin that lets you preview your current artboard in the Dock.
+- [Drafta](https://github.com/fragmentlv/drafta), by Fragment: Export designs directly to Drafta
 - [Drake](https://github.com/okcoker/Drake-Sketch-Plugin), by Sean Coker: Sketch app plugin for generating dummy Drake content such as photos and lyrics.
 - [draw-and-render](https://github.com/nichenqin/draw-and-render-sketch-plugin), by nichenqin: A plugin to render canvas to sketch
 - [ds-automator-sketch-plugin](https://github.com/pavelneznanov/ds-automator-sketch-plugin), by Pavel Neznanov: Tools for automating designer work

--- a/plugins.json
+++ b/plugins.json
@@ -4430,5 +4430,14 @@
     "appcast": "https://raw.githubusercontent.com/Ashung/Sketch-Stuffing/master/.appcast.xml",
     "homepage": "https://github.com/Ashung/Sketch-Stuffing",
     "author": "Ashung"
+  },
+  {
+    "title": "Drafta",
+    "description": "Export designs directly to Drafta",
+    "name": "drafta",
+    "owner": "fragmentlv",
+    "appcast": "https://raw.githubusercontent.com/fragmentlv/drafta/master/.appcast.xml",
+    "homepage": "https://github.com/fragmentlv/drafta",
+    "author": "Fragment"
   }
 ]


### PR DESCRIPTION
This is a Sketch plugin allows quick upload artboards to Drafta website. Drafta is a tool to keep track of project design screens and share them with others.

Thank you!