### PR TITLE
added description to bold-it/ysjn

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4627,12 +4627,12 @@
   },
   {
     "title": "bold-it",
+    "description": "Bold-it is a super simple plugin that bolds user-specified keyword in selected text layers.",
     "name": "bold-it",
     "owner": "ysjn",
     "appcast": "https://raw.githubusercontent.com/ysjn/bold-it/master/.appcast.xml",
     "homepage": "https://github.com/ysjn/bold-it",
-    "author": "ysjn",
-    "description": ""
+    "author": "ysjn"
   },
   {
     "title": "Pointbreak",


### PR DESCRIPTION
Hello Ale :wave:

Thanks for adding my plugin the other day.
It seems that I forgot to add my plugin's description.

I've added the description manually, but is there a specific way to update part of `plugins.json`(maybe with skpm)?
I didn't change any code in the actual plugin, but I only added the description.

I'm sorry to bother you with this small PR, but it would be great if you could point me to right direction.
Thanks!