### PR TITLE
Add the Droplr/Upload-to-Droplr plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4906,5 +4906,13 @@
     "appcast": "https://raw.githubusercontent.com/enriquezgomez/datazier-lens/master/.appcast.xml",
     "homepage": "https://github.com/enriquezgomez/datazier-lens",
     "author": "Victor Enriquez"
-  }
+  },
+  {
+    "title": "Droplr",
+    "description": "Droplr for Sketch lets designers quickly and easily share their Artboards",
+    "name": "Droplr",
+    "owner": "jimboroberts",
+    "homepage": "https://droplr.com/integrations/sketch/",
+    "author": "jimboroberts",
+  },
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -4914,5 +4914,5 @@
     "owner": "jimboroberts",
     "homepage": "https://droplr.com/integrations/sketch/",
     "author": "jimboroberts",
-  },
+  }
 ]


### PR DESCRIPTION
Hello 👋

This is a Sketch + Droplr Integration which lets designers quickly and easily share their artboards. More info can be found on [Droplr's website](https://droplr.com/integrations/sketch/). The source code of the plugin is [here](https://github.com/Droplr/sketch-upload-to-droplr).

Thanks!