### PR TITLE
Update Iconify plug-in data

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4941,12 +4941,12 @@
     "lastUpdated": "2019-01-25 02:14:05 UTC"
   },
   {
-    "title": "iconify",
+    "title": "Iconify",
     "description": "Iconify integration. Import MDI, FontAwesome, Jam, EmojiOne and many other icons to Sketch document.",
     "name": "iconify-sketch",
-    "owner": "iconify-design",
-    "appcast": "https://raw.githubusercontent.com/iconify-design/iconify-sketch/master/.appcast.xml",
-    "homepage": "https://github.com/iconify-design/iconify-sketch",
+    "owner": "iconify",
+    "appcast": "https://raw.githubusercontent.com/iconify/iconify-sketch/master/.appcast.xml",
+    "homepage": "https://github.com/iconify/iconify-sketch",
     "author": "Vjacheslav Trushkin",
     "lastUpdated": "2019-03-22 15:52:44 UTC"
   },

--- a/plugins.json
+++ b/plugins.json
@@ -4948,7 +4948,7 @@
     "appcast": "https://raw.githubusercontent.com/iconify/iconify-sketch/master/.appcast.xml",
     "homepage": "https://github.com/iconify/iconify-sketch",
     "author": "Vjacheslav Trushkin",
-    "lastUpdated": "2019-03-22 15:52:44 UTC"
+    "lastUpdated": "2019-05-07 08:14:36 UTC"
   },
   {
     "title": "Connection Flow Arrows",


### PR DESCRIPTION
Update Iconify plug-in entry in plugins.json

Iconify plug-in repository was moved from http://github.com/iconify-design/iconify-sketch to https://github.com/iconify/iconify-sketch