### PR TITLE
Fix appcast URL

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4217,7 +4217,7 @@
     "description": "This plugin gives you syncing names between Symbol masters and its instances.",
     "author": "griffin-stewie",
     "owner": "griffin-stewie",
-    "appcast": "https://github.com/griffin-stewie/SymbolNameSync/blob/master/.appcast.xml",
+    "appcast": "https://raw.githubusercontent.com/griffin-stewie/SymbolNameSync/master/.appcast.xml",
     "name": "SymbolNameSync",
     "lastUpdated": "2019-06-16 03:45:00 UTC"
   },


### PR DESCRIPTION
I fixed appcast URL for SymbolNameSync plugin. 