### PR TITLE
Updates the company name and the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [jerryipsum](https://github.com/vinceangeloni/jerryipsum), by Vince Angeloni: A Seinfeld data plugin for Sketch.
 - [Justinmind Sketch](https://github.com/vconesa/justinmind-sketch), by Justinmind: You can export artboards, layers and pages you’ve made in Sketch to Justinmind and turn them into interactive shareable prototypes.
 - [keyColor](https://github.com/kevingutowski/keycolor), by Kevin Gutowski: A Sketch plugin to apply colors via the keyboard.
-- [Keygaroo](https://keygaroo.ixco.io/), by IxCO: Keygaroo helps you learn keyboard shortcuts for the actions you use the most.
+- [Keygaroo](https://keygaroo.iandco.com/), by I&CO: Keygaroo helps you learn keyboard shortcuts for the actions you use the most.
 - [Kitchen](https://github.com/ant-design/kitchen), by Ant-Design: Make your design work delicious 🍽
 - [Kopie](https://kopie.io), by Kopie: The copy editing tool for web and product design
 - [Label Layers](https://github.com/franklymrshankly/Label_Layers), by Jonathan Tran: A Sketch plugin that labels selected layers

--- a/plugins.json
+++ b/plugins.json
@@ -5840,10 +5840,10 @@
     "title": "Keygaroo",
     "description": "Keygaroo helps you learn keyboard shortcuts for the actions you use the most.",
     "name": "Keygaroo",
-    "owner": "IxCO",
-    "appcast": "https://keygaroo.ixco.io/appcast.xml",
-    "homepage": "https://keygaroo.ixco.io/",
-    "author": "IxCO"
+    "owner": "I&CO",
+    "appcast": "https://keygaroo.iandco.com/appcast.xml",
+    "homepage": "https://keygaroo.iandco.com/",
+    "author": "I&CO"
   },
   {
     "title": "Context",


### PR DESCRIPTION
Updated the company name and the url. We just changed the company name and the url of the website, not the plugin itself.

This should have been included in the pull request https://github.com/sketchplugins/plugin-directory/pull/1006.