### PR TITLE
chore: remove old chemofill plugin entry — it has been renamed to ChemFill

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -5047,16 +5047,6 @@
     "lastUpdated": "2019-12-09 10:01:54 UTC"
   },
   {
-    "title": "chemofill",
-    "description": "A Chemical Structure data supplier plugin.",
-    "name": "chemofill",
-    "owner": "ahadik",
-    "appcast": "https://raw.githubusercontent.com/ahadik/chemofill/master/.appcast.xml",
-    "homepage": "https://github.com/ahadik/chemofill",
-    "author": "Alexander Hadik",
-    "lastUpdated": "2019-03-05 23:45:06 UTC"
-  },
-  {
     "title": "Overrides Manager",
     "description": "A Sketch plugin which makes managing overrides easier.",
     "name": "Sketch-Overrides-Manager",


### PR DESCRIPTION
I had to make a pretty sizeable update to this plugin, and in the process decided to change the name from ChemoFill to ChemFill. The former was too... "chemo"-y ya know? This PR just removes the chemofill entry from `plugins.json`. I have a separate PR up to add the plugin with the new name: https://github.com/sketchplugins/plugin-directory/pull/1113