### PR TITLE
Add Collapse All Artboards and Groups plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -6937,5 +6937,14 @@
     "homepage": "https://www.quest.ai/sketch",
     "author": "Quest AI",
     "lastUpdated": "2020-09-02 21:34:43 UTC"
+  },
+  {
+    "title": "Collapse All Artboards And Groups",
+    "description": "Collapse all artboards and groups in the current document.",
+    "name": "Collapse-All-Artboards-and-Groups",
+    "owner": "littlebusters",
+    "appcast": "https://raw.githubusercontent.com/littlebusters/Collapse-All-Artboards-and-Groups/master/.appcast.xml",
+    "homepage": "https://github.com/littlebusters/Collapse-All-Artboards-and-Groups",
+    "author": "littlebusters"
   }
 ]


### PR DESCRIPTION
Hello Sketch Team 👋

The plugin is [here](https://github.com/littlebusters/Collapse-All-Artboards-and-Groups) if you want to have a look.

Hope you are having a great day 😃