### PR TITLE
Spelly change author to Spelly Team

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7267,7 +7267,7 @@
   {
     "title": "Spelly",
     "description": "Spell checker by Spelly with auto-scanner, suggestions, and other powerful features",
-    "author": "Pavlo Bielik",
+    "author": "Spelly Team",
     "homepage": "https://spelly.io",
     "owner": "Spelly Team",
     "name": "Spelly",


### PR DESCRIPTION
Please, approve this changes, because author is a team, but not a person