### PR TITLE
Added Beatflyer Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 - [Base64 PNG Export](https://github.com/jawayang/sketch-base64-png-export), by james yang: sketch plugin for Export Data URI
 - [Baseline Offsetter](https://github.com/ozgurgunes/Sketch-Baseline-Offsetter), by Ozgur Gunes: Raise, lower, set or reset the baseline of multiple text layers with a single command.
 - [Batch Create Symbols](https://github.com/demersdesigns/sketch-batch-create-symbols), by Paul Demers: A plugin for Sketch to convert selected layers to individual symbols.
+- [Beatflyer Lite](https://beatflyer.com/), Animate your artboards in a few clicks with a lite and free version of the powerful Beatflyer.
 - [betterTypePanel](https://github.com/KevinGutowski/betterTypePanel), by Kevin Gutowski: A sketch plugin to help manage common OpenType properties
 - [BillUI](https://github.com/SimonTakman/BillUI), by Carl Albertsson & Simon Takman: Interactive artificial evolutionary tool in order to help you come up with design suggestions that are similar to your initial design.
 - [Blender](https://github.com/bunnieabc/blender), by bunnieabc: A sketch plugin to create awesome gradient layers
@@ -411,6 +412,7 @@ A list of Sketch plugins hosted at GitHub, in alphabetical order.
 
 ## Sorted by last update (newest on top)
 
+- [Beatflyer Lite](https://beatflyer.com/), Animate your artboards in a few clicks with a lite and free version of the powerful Beatflyer.
 - [Sketch Layer Name Check](https://github.com/pplcallmesatz/SketchDefaultNameCheck), by Satheesh Kumar S: Check the default sketch layer naming, this plugin is for the user who needs to standardise his Sketch layer namings.
 - [SVGO Compressor](https://sketch.com/extensions/plugins/svgo-compressor/), by Sketch BV: A Plugin that compresses SVG assets using SVGO, right when you export them. This Plugin requires Sketch 3.8.
 - [Tiled for Sketch](https://tiled.co/tiled-for-sketch-plugin), by Tiled Inc.: Sync screens, hotspots, and feedback directly from Sketch to Tiled to create interactive microapps without code.

--- a/plugins.json
+++ b/plugins.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Beatflyer Lite",
+    "description": "Animate your artboards in a few clicks with a lite and free version of Beatflyer.",
+    "author": "Christian Giordano",
+    "homepage": "https://beatflyer.com",
+    "appcast": "https://beatflyer.com/lite/sketch/appcast.xml",
+    "name": "beatflyer-lite",
+    "lastUpdated": "2021-11-05 18:00:00 UTC"
+  },
+  {
     "title": "Sketch Layer Name Check",
     "description": "Check the default sketch layer naming, this plugin is for the user who needs to standardise his Sketch layer namings.",
     "author": "Satheesh Kumar S",


### PR DESCRIPTION
New plugin. It's the lite version of the standalone app [Beatflyer](https://beatflyer.com/). Works similarly to the [popular version](https://www.figma.com/community/plugin/776923340646658146/BeatFlyer-Lite) available for Figma.