### PR TITLE
Remove Gallery (formally known as Material Plugin)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4009,13 +4009,6 @@
     "lastUpdated": "2021-08-10 17:58:35 UTC"
   },
   {
-    "description": "Quickly upload and sync Sketch artboards to Gallery collections.",
-    "title": "Gallery",
-    "author": "Google LLC",
-    "homepage": "https://material.io/resources/gallery",
-    "lastUpdated": "2020-03-16 22:08:00 UTC"
-  },
-  {
     "title": "Sketch Style To React Native",
     "description": "Sketch plugin that copies an element's styles in React Native way directly to your Mac clipboard.",
     "name": "sketch-style-to-react-native",


### PR DESCRIPTION
Removing from the plugin list, as Gallery.io moved into maintenance mode.

Reference:
https://support.google.com/materialgallery/answer/11044972?hl=en&ref_topic=11045865

Related PR:
https://github.com/sketchplugins/plugin-directory/pull/1110