### PR TITLE
Update Awesome Ipsums to the version 1.1.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -5873,7 +5873,7 @@
     "appcast": "https://raw.githubusercontent.com/inVoltag/awesome-ipsums/master/.appcast.xml",
     "homepage": "https://github.com/inVoltag/awesome-ipsums",
     "author": "Aurélien Grimaud",
-    "lastUpdated": "2021-08-11 12:10:22 UTC"
+    "lastUpdated": "2021-12-10 12:10:22 UTC"
   },
   {
     "title": "Sketch Pexels",


### PR DESCRIPTION
What's changed:
        - API Workflow has changed because Google has stopped to support the V3 API (thanks to @benborgers for his fantastic API [opensheet](https://github.com/benborgers/opensheet))
        - The sheet name is required to make the plugin operate