### PR TITLE
Update plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7331,5 +7331,13 @@
     "appcast": "https://thegoldenratio.pages.dev/.appcast.xml",
     "homepage": "https://www.thegoldenratio.co.uk/plugins",
     "author": "Spacestar Digital"
+  },
+  {
+    "title": "Live Preview",
+    "description": "Wirelessly mirror Sketch artboards on iPhone and iPad, with pixel–perfect rendering.",
+    "author": "Kyle Halevi",
+    "homepage": "https://kylehalevi.com/live-preview/",
+    "appcast": "https://kylehalevi.com/live-preview/plugin-appcast.xml",
+    "name": "LivePreview"
   }
 ]


### PR DESCRIPTION
Live Preview is a new plugin for Sketch that lets anyone mirror their artboard to their iPhone or iPad, wirelessly and pixel–perfectly.

Here's a link to the homepage: https://kylehalevi.com/live-preview/
And here's a link to the plugin itself (which is included with the Mac app): https://kylehalevi.com/live-preview/LivePreview.sketchplugin-1.0.zip