### PR TITLE
fix: add lastUpdated info to plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7284,6 +7284,7 @@
     "owner": "Codia.AI",
     "appcast": "https://codia-f2c.s3.us-west-1.amazonaws.com/sketch/.appcast.xml",
     "homepage": "https://codia.ai/",
-    "author": "Codia.AI"
+    "author": "Codia.AI",
+    "lastUpdated": "2024-07-01 10:20:05 UTC"
   }
 ]


### PR DESCRIPTION
Add missing 'lastUpdated' property to plugin to make it show up.