### PR TITLE
fix: remove CI HUB plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -61,15 +61,6 @@
     "lastUpdated": "2022-10-24 08:05:00 UTC"
   },
   {
-    "title": "CI HUB Connector",
-    "description": "Add images/text to your designs directly from wherever they are, directly in Sketch. Access Stock Images or use your workflow for approval. Share with your Team in Dropbox or Google Drive and more. And never leave Sketch.",
-    "author": "CI HUB GmbH",
-    "homepage": "https://ci-hub.com/sketch",
-    "appcast": "https://ci-hub.azurewebsites.net/download/sketch.xml",
-    "name": "com.ci-hub.ci-hub-connector",
-    "lastUpdated": "2021-11-19 15:00:00 UTC"
-  },
-  {
     "title": "Beatflyer Lite",
     "description": "Animate your artboards in a few clicks with a lite and free version of Beatflyer.",
     "author": "Christian Giordano",


### PR DESCRIPTION
Remove CI Hub plugin from the list because the Sketch page inside its website (https://ci-hub.com/sketch) is 404ing and the integration is no longer listed.