### PR TITLE
Update UI Color Palette plugin details and formatting

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7187,9 +7187,11 @@
     "description": "Color Palettes that meet WCAG Guidelines and Operations",
     "owner": "a-ng-d",
     "author": "Aurélien Grimaud",
-    "homepage": "https://uicp.ylb.lt/website",
+    "homepage": "https://uicp.ylb.lt/website-download",
+    "version": "5.3.0",
     "lastUpdated": "2026-04-07 14:07:04 UTC",
     "appcast": "https://raw.githubusercontent.com/a-ng-d/sketch-ui-color-palette/refs/heads/dev/appcast.json"
+    "icon": "https://raw.githubusercontent.com/a-ng-d/sketch-ui-color-palette/refs/heads/dev/assets/uicp_icon.png"
   },
   {
     "title": "Circular Text",

--- a/plugins.json
+++ b/plugins.json
@@ -7190,7 +7190,7 @@
     "homepage": "https://uicp.ylb.lt/website-download",
     "version": "5.3.0",
     "lastUpdated": "2026-04-07 14:07:04 UTC",
-    "appcast": "https://raw.githubusercontent.com/a-ng-d/sketch-ui-color-palette/refs/heads/dev/appcast.json"
+    "appcast": "https://raw.githubusercontent.com/a-ng-d/sketch-ui-color-palette/refs/heads/dev/appcast.json",
     "icon": "https://raw.githubusercontent.com/a-ng-d/sketch-ui-color-palette/refs/heads/dev/assets/uicp_icon.png"
   },
   {


### PR DESCRIPTION
This pull request makes minor metadata updates to the UI Color Palette plugin entry in the `plugins.json` file. The changes update the homepage URL, set a new version number, and add an icon URL to improve the plugin's listing.

- Metadata updates for the UI Color Palette plugin:
  * Updated the `homepage` URL to a new address.
  * Set the `version` to `5.3.0`.
  * Added an `icon` URL for the plugin.