### PR TITLE
Add Sketch to Icon Composer

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7283,5 +7283,16 @@
     "homepage": "https://www.typeui.sh/",
     "author": "Bergside",
     "lastUpdated": "2026-05-16 08:09:28 UTC"
+  },
+  {
+    "title": "Sketch to Icon Composer",
+    "description": "Copies each top-level layer of the selected frame to the clipboard as full-frame SVG files, ready to drop into Apple's Icon Composer.",
+    "name": "sketch-to-icon-composer",
+    "owner": "yoshi2ys",
+    "version": "1.0.0",
+    "appcast": "https://github.com/yoshi2ys/sketch-to-icon-composer/releases/latest/download/appcast.json",
+    "homepage": "https://github.com/yoshi2ys/sketch-to-icon-composer",
+    "author": "yoshi2ys",
+    "lastUpdated": "2026-06-15 15:55:42 UTC"
   }
 ]


### PR DESCRIPTION
Adds `yoshi2ys/sketch-to-icon-composer` to the directory.

A raw Sketch plugin (no skpm) that exports each top-level layer of a selected icon frame as a **full-frame SVG** and copies the files to the clipboard, ready to drop into Apple's [Icon Composer](https://developer.apple.com/icon-composer/) as individual Liquid Glass layers. Filenames are numbered to preserve front-to-back stacking order on import.

Includes an `appcast.json` (attached to GitHub Releases) for auto-updates.

Repo: https://github.com/yoshi2ys/sketch-to-icon-composer