### PR TITLE
Hotfix: Update Component Browser to v1.4.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7207,9 +7207,9 @@
     "owner": "funk4d",
     "homepage": "https://github.com/funk4d/Component-Browser-Sketch-Plugin",
     "identifier": "com.funkyplugins.componentbrowser",
-    "version": "1.3.0",
+    "version": "1.4.1",
     "appcast": "https://raw.githubusercontent.com/funk4d/Component-Browser-Sketch-Plugin/main/appcast.json",
-    "lastUpdated": "2026-05-27 00:00:00 UTC",
+    "lastUpdated": "2026-06-23 00:00:00 UTC",
     "icon": "https://raw.githubusercontent.com/funk4d/Component-Browser-Sketch-Plugin/main/github/component-browser-icon.png"
   },
   {


### PR DESCRIPTION
Hotfix update for Component Browser.

- Updates the directory version from `1.3.0` to `1.4.1`.
- Stops background preview generation while the browser is hidden, preventing Sketch freezes after creating local Symbols.
- Updates `lastUpdated` to `2026-06-23 00:00:00 UTC`.

Validation: `plugins.json` parses successfully as JSON.